### PR TITLE
Add FastAPI example scaffold

### DIFF
--- a/FASTAPI_GUIDE.md
+++ b/FASTAPI_GUIDE.md
@@ -1,0 +1,24 @@
+# FastAPI Setup
+
+This repository primarily contains a Ruby on Rails application. The `fastapi_app/` directory provides a minimal FastAPI example that can serve as a starting point for rewriting functionality in Python.
+
+## Structure
+
+```
+fastapi_app/
+  app/
+    main.py          # FastAPI application entrypoint
+  requirements.txt   # Python dependencies
+  Dockerfile         # Container image for the API
+```
+
+A Docker Compose file (`docker-compose.fastapi.yml`) is included at the repository root to run the API alongside a PostgreSQL database.
+
+## Running with Docker Compose
+
+```bash
+docker compose -f docker-compose.fastapi.yml build
+docker compose -f docker-compose.fastapi.yml up
+```
+
+The API will be available at `http://localhost:8000/`.

--- a/docker-compose.fastapi.yml
+++ b/docker-compose.fastapi.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: aact
+      POSTGRES_USER: aact
+      POSTGRES_PASSWORD: password
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  api:
+    build: ./fastapi_app
+    environment:
+      DATABASE_URL: postgres://aact:password@db:5432/aact
+    volumes:
+      - ./fastapi_app/app:/app/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+volumes:
+  pgdata:

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi_app/README.md
+++ b/fastapi_app/README.md
@@ -1,0 +1,25 @@
+# FastAPI Example for AACT
+
+This folder contains a minimal FastAPI application that acts as a placeholder for a future Python implementation of the AACT service.
+
+## Folder Structure
+
+```
+fastapi_app/
+  app/
+    main.py          # FastAPI application entrypoint
+  requirements.txt   # Python dependencies
+  Dockerfile         # Image to run the service
+```
+
+## Usage with Docker Compose
+A sample `docker-compose` file is available at the repository root named `docker-compose.fastapi.yml`.
+
+Build and run the application:
+
+```bash
+docker compose -f docker-compose.fastapi.yml build
+docker compose -f docker-compose.fastapi.yml up
+```
+
+The API will be available at `http://localhost:8000/`.

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "AACT FastAPI placeholder"}

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add minimal FastAPI application under `fastapi_app/`
- include Dockerfile and requirements for FastAPI example
- provide a docker compose file for running FastAPI with PostgreSQL
- document FastAPI usage in `FASTAPI_GUIDE.md`

## Testing
- `bundle exec rspec` *(fails: rbenv: version `2.7.7` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687df2dc77488326adee33bc5ddf84b0